### PR TITLE
Add tree browsers for IEDB trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,22 @@
 #
 # - `./src/run.py` run.py
 
+build:
+	mkdir -p $@
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+	RDFTAB_URL := https://github.com/ontodev/rdftab.rs/releases/download/v0.1.1/rdftab-x86_64-apple-darwin
+else
+	RDFTAB_URL := https://github.com/ontodev/rdftab.rs/releases/download/v0.1.1/rdftab-x86_64-unknown-linux-musl
+endif
+
+build/rdftab: | build
+	curl -L -o $@ $(RDFTAB_URL)
+	chmod +x $@
+
+### Tables
+
 GSURL := "https://docs.google.com/spreadsheets/d/1oy2NSxb6er3-QQ7bZMKqSpOOVSCAeg7qPII-VD2ahk8/"
 
 src/resources/table.tsv:
@@ -17,3 +33,21 @@ src/resources/datatype.tsv:
 update-meta-tables:
 	rm -f src/resources/*.tsv
 	make src/resources/table.tsv src/resources/column.tsv src/resources/datatype.tsv
+
+### Tree Browser
+
+TREES = organism-tree subspecies-tree protein-tree nonpeptide-tree molecule-tree assay-tree disease-tree geolocation
+DBS = $(foreach T,$(TREES),build/$(T).db)
+
+dbs: $(DBS)
+
+build/%.db: src/prefixes.sql build/%.owl | build/rdftab
+	rm -rf $@
+	sqlite3 $@ < $<
+	./build/rdftab $@ < $(word 2,$^)
+	sqlite3 $@ "CREATE INDEX idx_stanza ON statements (stanza);"
+	sqlite3 $@ "CREATE INDEX idx_subject ON statements (subject);"
+	sqlite3 $@ "CREATE INDEX idx_predicate ON statements (predicate);"
+	sqlite3 $@ "CREATE INDEX idx_object ON statements (object);"
+	sqlite3 $@ "CREATE INDEX idx_value ON statements (value);"
+	sqlite3 $@ "ANALYZE;"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # curatron
 Prototype curation system
+
+## Tree Browser
+
+To run the tree browser, you first need to place the following files (from IEDB) in the `build/` directory: `assay-tree.owl`, `disease-tree.owl`, `geolocation.owl`, `molecule-tree.owl`, `nonpeptide-tree.owl`, `organism-tree.owl`, `protein-tree.owl`, and `subspecies-tree.owl`.
+
+Then, create the SQLite databases:
+```bash
+make dbs
+```
+
+Finally, you can run the Flask app to see the tree browsers, which are located at the `/browse` path:
+```bash
+export FLASK_APP=src/run.py
+flask run
+```
+
+You can also run this app as a CGI script.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask
+ontodev-gizmos
 requests
+SQLAlchemy

--- a/src/prefixes.sql
+++ b/src/prefixes.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS prefix (
+  prefix TEXT PRIMARY KEY,
+  base TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO prefix VALUES
+("rdf",  "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+("xsd",  "http://www.w3.org/2001/XMLSchema#"),
+("owl",  "http://www.w3.org/2002/07/owl#"),
+("oio",  "http://www.geneontology.org/formats/oboInOwl#"),
+("dce",  "http://purl.org/dc/elements/1.1/"),
+("dct",  "http://purl.org/dc/terms/"),
+("foaf", "http://xmlns.com/foaf/0.1/"),
+
+-- OBO prefixes
+("obo",        "http://purl.obolibrary.org/obo/"),
+("DOID",       "http://purl.obolibrary.org/obo/DOID_"),
+("GAZ",        "http://purl.obolibrary.org/obo/GAZ_"),
+("NCBITaxon",  "http://purl.obolibrary.org/obo/NCBITaxon_"),
+("ncbitaxon",  "http://purl.obolibrary.org/obo/ncbitaxon#"),
+("OBI",        "http://purl.obolibrary.org/obo/OBI_"),
+
+-- IEDB prefixes
+("annotation",    "http://purl.uniprot.org/annotation/"),
+("nonpep",        "https://ontology.iedb.org/nonpeptide/"),
+("ONTIE",      "https://ontology.iedb.org/ontology/ONTIE_"),
+("protein",       "https://ontology.iedb.org/protein/"),
+("role",          "https://ontology.iedb.org/by-role/"),
+("taxon",         "https://ontology.iedb.org/taxon/"),
+("taxon-protein", "https://ontology.iedb.org/taxon-protein/"),
+("uniprot",       "http://www.uniprot.org/uniprot/");

--- a/src/resources/browse.html
+++ b/src/resources/browse.html
@@ -1,0 +1,15 @@
+{% extends "template.html" %}
+{% block content %}
+
+<div class="container">
+    <div class="row" style="padding-top:10px;">
+        <h3>Select a tree:</h3>
+        <ul>
+            {% for t in trees %}
+            <li><a href="./browse/{{ t }}">{{ t }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
+{% endblock %}

--- a/src/resources/template.html
+++ b/src/resources/template.html
@@ -33,6 +33,8 @@
 	</style>
 </head>
 <body>
-  {{ content }}
+	{% block content %}
+	{{ default|safe }}
+	{% endblock %}
 </body>
 </html>

--- a/src/resources/tree.html
+++ b/src/resources/tree.html
@@ -1,0 +1,9 @@
+{% extends "template.html" %}
+{% block content %}
+
+<div class="container">
+    {{ tree|safe }}
+    <div class="fixed-bottom" style="padding-bottom:10px; padding-left:10px"><a href="/browse">View all trees</a></div>
+</div>
+
+{% endblock %}

--- a/src/run.py
+++ b/src/run.py
@@ -37,6 +37,9 @@ def list_trees():
 
 @app.route("/browse/<tree>")
 def show_tree(tree):
+    if tree == "style.css":
+        # Do nothing - workaround for unknown stylesheet
+        return render_template("template.html")
     conn = create_connection(tree)
     fmt = request.args.get("format")
     if fmt and fmt == "json":
@@ -57,6 +60,9 @@ def show_tree(tree):
 
 @app.route("/browse/<tree>/<term>")
 def show_term(tree, term):
+    if tree == "style.css":
+        # Do nothing - workaround for unknown stylesheet
+        return render_template("template.html")
     conn = create_connection(tree)
     fmt = request.args.get("format")
     if fmt and fmt == "json":

--- a/src/run.py
+++ b/src/run.py
@@ -1,25 +1,82 @@
 #! /usr/bin/env python3
 
-import csv
-import json
 import os
 
-from argparse import ArgumentParser
-from flask import abort, Flask, render_template, request, Response
+from flask import Flask, render_template, request
+from gizmos.search import search
+from gizmos.tree import tree as render_tree
+from sqlalchemy import create_engine
 from wsgiref.handlers import CGIHandler
 
 app = Flask(
-    __name__,
-    template_folder=os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "resources")
-    ),
+    __name__, template_folder=os.path.abspath(os.path.join(os.path.dirname(__file__), "resources")),
 )
 app.url_map.strict_slashes = False
+
+TREES = [
+    "organism",
+    "subspecies",
+    "protein",
+    "nonpeptide",
+    "molecule",
+    "assay",
+    "disease",
+    "geolocation",
+]
 
 
 @app.route("/")
 def index():
-    return render_template("template.html", content="Hello")
+    return render_template("template.html", default="Hello")
+
+
+@app.route("/browse")
+def list_trees():
+    return render_template("browse.html", trees=TREES)
+
+
+@app.route("/browse/<tree>")
+def show_tree(tree):
+    conn = create_connection(tree)
+    fmt = request.args.get("format")
+    if fmt and fmt == "json":
+        # Return search results
+        data = search(conn, request.args.get("text"))
+        return data
+    html = render_tree(
+        conn,
+        tree,
+        None,
+        href="./" + tree + "/{curie}",
+        title="",
+        include_search=True,
+        standalone=True,
+    )
+    return render_template("tree.html", tree=html)
+
+
+@app.route("/browse/<tree>/<term>")
+def show_term(tree, term):
+    conn = create_connection(tree)
+    fmt = request.args.get("format")
+    if fmt and fmt == "json":
+        # Return search results
+        data = search(conn, request.args.get("text"))
+        return data
+    html = render_tree(
+        conn, tree, term, href="./{curie}", title="", include_search=True, standalone=True
+    )
+    return render_template("tree.html", tree=html)
+
+
+def create_connection(tree):
+    if tree == "geolocation":
+        path = "build/geolocation.db"
+    else:
+        path = f"build/{tree}-tree.db"
+    abspath = os.path.abspath(path)
+    db_url = "sqlite:///" + abspath
+    return create_engine(db_url)
 
 
 def main():


### PR DESCRIPTION
I *think* I got all the prefixes. I browsed through the various trees and didn't run into any issues, but I'd appreciate a second set of eyes. From the README:

## Tree Browser

To run the tree browser, you first need to place the following files (from IEDB) in the `build/` directory: `assay-tree.owl`, `disease-tree.owl`, `geolocation.owl`, `molecule-tree.owl`, `nonpeptide-tree.owl`, `organism-tree.owl`, `protein-tree.owl`, and `subspecies-tree.owl`.

Then, create the SQLite databases:
```bash
make dbs
```

Finally, you can run the Flask app to see the tree browsers, which are located at the `/browse` path:
```bash
export FLASK_APP=src/run.py
flask run
```

You can also run this app as a CGI script.